### PR TITLE
add integration test with a real Worker class

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,20 +1,24 @@
+class HelloService
+  def self.call(arg)
+  end
+end
+
 class HelloWorker
   include Sidekiq::Worker
 
   def perform(arg)
-    arg
+    HelloService.call(arg)
   end
 end
 
 RSpec.describe 'Sidekiq Integration', type: :integration do
-  describe 'HelloWorker.perform_async(1)' do
-    subject { HelloWorker.perform_async(1) }
+  describe 'HelloWorker.perform_async' do
+    let(:arg) { SecureRandom.hex }
 
-    it 'HelloWorker receives :new, :perform with 1' do
-      instance = HelloWorker.new
-      expect(HelloWorker).to receive(:new) { instance }
-      expect(instance).to receive(:perform).with(1)
-      subject
+    it 'executes instance with given arg' do
+      expect(HelloService).to receive(:call).with(arg)
+
+      HelloWorker.perform_async(arg)
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,0 +1,20 @@
+class HelloWorker
+  include Sidekiq::Worker
+
+  def perform(arg)
+    arg
+  end
+end
+
+RSpec.describe 'Sidekiq Integration', type: :integration do
+  describe 'HelloWorker.perform_async(1)' do
+    subject { HelloWorker.perform_async(1) }
+
+    it 'HelloWorker receives :new, :perform with 1' do
+      instance = HelloWorker.new
+      expect(HelloWorker).to receive(:new) { instance }
+      expect(instance).to receive(:perform).with(1)
+      subject
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,10 @@
 require 'bundler/setup'
 require 'pry'
 require 'sidekiq/cli'
+require 'sidekiq/testing'
 require 'newrelic-sidekiq-metrics'
+
+Sidekiq::Testing.inline!
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
@@ -16,5 +19,11 @@ RSpec.configure do |config|
 
   config.after(:each) do |example|
     NewrelicSidekiqMetrics.use(NewrelicSidekiqMetrics::DEFAULT_ENABLED_METRICS)
+  end
+
+  config.before(:each, type: :integration) do
+    Sidekiq::Testing.server_middleware do |chain|
+      chain.add NewrelicSidekiqMetrics::Middleware
+    end
   end
 end


### PR DESCRIPTION
Ensure that #perform is received by an instance of a worker when this middleware is in the Sidekiq server_middleware chain.  Ideally this integration test and the `before(:each, type: :integration)` setup doesn't ever change regardless of changes to this gem's API.

@knapo this is just one more safeguard, what do you think?