### PR TITLE
Skip connecting redis in sidekiq inline mode

### DIFF
--- a/lib/newrelic_sidekiq_metrics.rb
+++ b/lib/newrelic_sidekiq_metrics.rb
@@ -50,6 +50,10 @@ module NewrelicSidekiqMetrics
       end
     end
   end
+
+  def self.inline_sidekiq?
+    defined?(Sidekiq::Testing) && Sidekiq::Testing.inline?
+  end
 end
 
 NewrelicSidekiqMetrics.add_client_middleware

--- a/lib/newrelic_sidekiq_metrics/recorder.rb
+++ b/lib/newrelic_sidekiq_metrics/recorder.rb
@@ -10,14 +10,19 @@ module NewrelicSidekiqMetrics
       metrics.each { |m| record_metric(m) }
     end
 
+    private
+
     def stats
       @stats ||= Sidekiq::Stats.new
     end
 
-    private
+    def get_stat(name)
+      return 0 if NewrelicSidekiqMetrics.inline_sidekiq?
+      stats.public_send(name)
+    end
 
     def record_metric(name)
-      NewRelic::Agent.record_metric(metric_full_name(name), stats.public_send(name))
+      NewRelic::Agent.record_metric(metric_full_name(name), get_stat(name))
     end
 
     def metric_full_name(name)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe 'Sidekiq Integration', type: :integration do
     it 'executes instance with given arg' do
       expect(HelloService).to receive(:call).with(arg)
 
-      HelloWorker.perform_async(arg)
+      Sidekiq::Testing.inline! do
+        HelloWorker.perform_async(arg)
+      end
     end
   end
 end

--- a/spec/newrelic_sidekiq_metrics/recorder_spec.rb
+++ b/spec/newrelic_sidekiq_metrics/recorder_spec.rb
@@ -1,14 +1,37 @@
 RSpec.describe NewrelicSidekiqMetrics::Recorder do
   describe '#call' do
-    before do
-      NewrelicSidekiqMetrics.use(:enqueued, :workers_size)
+    context 'with inline sidekiq mode' do
+      around do |example|
+        Sidekiq::Testing.inline! do
+          example.run
+        end
+      end
+
+      specify do
+        expect(NewrelicSidekiqMetrics.inline_sidekiq?).to eq(true)
+
+        NewrelicSidekiqMetrics.use(:enqueued, :workers_size)
+
+        expect(Sidekiq::Stats).not_to receive(:new)
+        expect(NewRelic::Agent).to receive(:record_metric).with('Custom/Sidekiq/EnqueuedSize', 0).and_call_original
+        expect(NewRelic::Agent).to receive(:record_metric).with('Custom/Sidekiq/WorkersSize', 0).and_call_original
+
+        subject.call
+      end
     end
 
-    it do
-      expect(NewRelic::Agent).to receive(:record_metric).with('Custom/Sidekiq/EnqueuedSize', 0).and_call_original
-      expect(NewRelic::Agent).to receive(:record_metric).with('Custom/Sidekiq/WorkersSize', 0).and_call_original
+    context 'with default sidekiq mode' do
+      specify do
+        expect(NewrelicSidekiqMetrics.inline_sidekiq?).to eq(false)
 
-      subject.call
+        NewrelicSidekiqMetrics.use(:enqueued, :workers_size)
+
+        expect(Sidekiq::Stats).to receive(:new).and_call_original
+        expect(NewRelic::Agent).to receive(:record_metric).with('Custom/Sidekiq/EnqueuedSize', 0).and_call_original
+        expect(NewRelic::Agent).to receive(:record_metric).with('Custom/Sidekiq/WorkersSize', 0).and_call_original
+
+        subject.call
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,6 @@ require 'sidekiq/cli'
 require 'sidekiq/testing'
 require 'newrelic-sidekiq-metrics'
 
-Sidekiq::Testing.inline!
-
 RSpec.configure do |config|
   config.disable_monkey_patching!
 


### PR DESCRIPTION
## Description
Skip connecting redis in sidekiq inline mode

## Motivation and Context
When sidekiq is working in inline mode, connecting redis and fetching stats doesn't make sense and only require having redis running, when it doesn't need to be there.