### PR TITLE
Update newrelic-sidekiq-metrics.gemspec to allow newrelic_rpm 9.x

### DIFF
--- a/newrelic-sidekiq-metrics.gemspec
+++ b/newrelic-sidekiq-metrics.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'newrelic_rpm', '~> 8'
+  spec.add_dependency 'newrelic_rpm', ['~> 8.0', '~> 9.0']
   spec.add_dependency 'sidekiq'
 end


### PR DESCRIPTION
## Description, motivation and context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I need to use newrelic_rpm 9.x

## Related issue(s) or PR(s)
<!--- GH issue number -->
